### PR TITLE
Revive fixes

### DIFF
--- a/ADV120_MissionTemplate.Altis/f/revive/fn_SetDowned.sqf
+++ b/ADV120_MissionTemplate.Altis/f/revive/fn_SetDowned.sqf
@@ -99,7 +99,7 @@ if (_bool && {alive _unit}) then {
         private _animList = getArray (configfile >> "CfgMovesMaleSdr" >> "States" >> animationState _unit >> "interpolateTo");
         private _newAnim = "passenger_inside_2_Die";
         private _newAnimSelected = false;
-        disableUserInput true;
+        if (local _unit) then { disableUserInput true; };
         {
             if (_x isEqualType "") then {
                 if (["die",toLower(_x)] call bis_fnc_inString) then {
@@ -197,4 +197,5 @@ if (_bool && {alive _unit}) then {
         };
         _unit setDamage 0;
     };
+    if (local _unit) then { disableUserInput false; };
 };

--- a/ADV120_MissionTemplate.Altis/f/revive/fn_SetDowned.sqf
+++ b/ADV120_MissionTemplate.Altis/f/revive/fn_SetDowned.sqf
@@ -81,8 +81,8 @@ if (_bool && {alive _unit}) then {
                 _unit removeMagazine _x;
                 _magazineList pushBack _x;
             };
-            
-        } forEach magazinesAmmoFull _unit;
+            false
+        } count magazinesAmmoFull _unit;
         _unit setVariable ["phx_revive_down_mags",_magazineList];
         
         // Disable TFAR speech
@@ -99,6 +99,7 @@ if (_bool && {alive _unit}) then {
         private _animList = getArray (configfile >> "CfgMovesMaleSdr" >> "States" >> animationState _unit >> "interpolateTo");
         private _newAnim = "passenger_inside_2_Die";
         private _newAnimSelected = false;
+        disableUserInput true;
         {
             if (_x isEqualType "") then {
                 if (["die",toLower(_x)] call bis_fnc_inString) then {
@@ -107,7 +108,8 @@ if (_bool && {alive _unit}) then {
                 };
             };
             if (_newAnimSelected) exitWith {};
-        } forEach _animList;
+            false
+        } count _animList;
         if (isNil "_newAnim") then {_newAnim = ""};
         _unit switchMove _newAnim;
         
@@ -169,7 +171,8 @@ if (_bool && {alive _unit}) then {
         private _mags = _unit getVariable ["phx_revive_down_mags",magazines _unit];
         {
             _unit addMagazine _x;
-        } forEach _mags;
+            false
+        } count _mags;
         
         // Reset the respawn variables
         player setVariable ["phx_revive_respawnRevive",true,true];


### PR DESCRIPTION
- Changed 'forEach' to 'count' in a couple files, since 'count' is faster than 'forEach'.
- Disabled user input if player is downed in a vehicle turret that way they can't use the turret to look around and shoot.
- Added locality checks to make sure 'disableUserInput' is ran on the correct machine/client.
